### PR TITLE
Bash script to automate the subdomain enumeration using certificate transparency logs.Add files via upload

### DIFF
--- a/cert.sh
+++ b/cert.sh
@@ -1,0 +1,1 @@
+curl -s https://crt.sh/?Identity=%.$1 | grep ">*.$1" | sed 's/<[/]*[TB][DR]>/\n/g' | grep -vE "<|^[\*]*[\.]*$1" | sort -u | awk 'NF'


### PR DESCRIPTION
Bash script to automate the subdomain enumeration using certificate transparency logs.